### PR TITLE
Added a dialog box for message errors or success in Contact page

### DIFF
--- a/src/components/dialog.jsx
+++ b/src/components/dialog.jsx
@@ -1,0 +1,32 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function Dialog({ children, state }) {
+	const dialogRef = useRef();
+
+	/* causes our dialog box to show if message is sent successfully */
+	useEffect(() => {
+		state ? dialogRef.current?.showModal() : dialogRef.current?.close();
+	}, [state]);
+
+	/* close our dialog box */
+	const closeDialog = () => {
+		dialogRef.current?.close();
+	};
+
+	return (
+		<dialog
+			ref={dialogRef}
+			className='fixed top-50 left-50 -translate-x-50 -translate-y-50 z-10  rounded-xl backdrop:bg-gray-800/50'>
+			<div className='md:w-[500px] max-w-full bg-gray-200 flex flex-col'>
+				<div className='flex flex-row justify-between mb-4 pt-2 px-5 bg-yellow-400'>
+					<button
+						onClick={closeDialog}
+						className='mb-2 py-1 px-2 cursor-pointer rounded border-none w-8 h-8 font-bold bg-red-600 text-white'>
+						x
+					</button>
+				</div>
+				<div className='px-5 pb-6'>{children}</div>
+			</div>
+		</dialog>
+	);
+}

--- a/src/components/emailForm.jsx
+++ b/src/components/emailForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Dialog from './dialog';
 
 const EmailFormComponent = ({
 	form,
@@ -16,14 +17,24 @@ const EmailFormComponent = ({
 				</span>
 			)} */}
 			{success && (
-				<span className='text-green-600 font-semibold text-sm md:text-lg text-center md:-mb-6'>
-					Message sent successfully!
-				</span>
+				// <span className='text-green-600 font-semibold text-sm md:text-lg text-center md:-mb-6'>
+				// 	Message sent successfully!
+				// </span>
+				<Dialog state={success}>
+					<p className='text-center flex items-center justify-center text-base md:text-2xl font-semibold'>
+						Message sent successfully!
+					</p>
+				</Dialog>
 			)}
 			{error && (
-				<span className='text-red-600 font-semibold text-sm md:text-lg text-center md:-mb-6'>
-					Message not sent!
-				</span>
+				// <span className='text-red-600 font-semibold text-sm md:text-lg text-center md:-mb-6'>
+				// 	Message not sent!
+				// </span>
+				<Dialog state={error}>
+					<p className='text-center flex items-center justify-center text-base md:text-2xl font-semibold'>
+						Message not sent!
+					</p>
+				</Dialog>
 			)}
 			<form
 				ref={form}


### PR DESCRIPTION
I completed the dialog box code to inform users of the success or failures of their messages to the endpoint by using `useRef` hook and `showModal`.