### PR TITLE
moved close button to right on modal

### DIFF
--- a/src/components/dialog.jsx
+++ b/src/components/dialog.jsx
@@ -18,7 +18,7 @@ export default function Dialog({ children, state }) {
 			ref={dialogRef}
 			className='fixed top-50 left-50 -translate-x-50 -translate-y-50 z-10  rounded-xl backdrop:bg-gray-800/50'>
 			<div className='md:w-[500px] max-w-full bg-gray-200 flex flex-col'>
-				<div className='flex flex-row justify-between mb-4 pt-2 px-5 bg-yellow-400'>
+				<div className='flex flex-row justify-end mb-4 pt-2 px-5 bg-yellow-400'>
 					<button
 						onClick={closeDialog}
 						className='mb-2 py-1 px-2 cursor-pointer rounded border-none w-8 h-8 font-bold bg-red-600 text-white'>


### PR DESCRIPTION
I moved the close button on the modal to the right using tailwindcss `justify-end`.